### PR TITLE
Feat/wave spawns

### DIFF
--- a/src/main/java/city/emerald/bastion/wave/MobSpawnManager.java
+++ b/src/main/java/city/emerald/bastion/wave/MobSpawnManager.java
@@ -11,6 +11,7 @@ import java.util.TreeSet;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -19,6 +20,7 @@ import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -162,9 +164,12 @@ public class MobSpawnManager implements Listener {
       .getWorld()
       .spawnEntity(spawnLoc, mobType);
 
-    // Make zombies immune to sunlight
-    if (mob instanceof org.bukkit.entity.Zombie) {
-      ((org.bukkit.entity.Zombie) mob).setShouldBurnInDay(false);
+    // Equip mobs to prevent them from burning in daylight
+    if (mob instanceof org.bukkit.entity.Zombie || mob instanceof org.bukkit.entity.Skeleton) {
+        if (mob.getEquipment() != null) {
+            mob.getEquipment().setHelmet(new ItemStack(Material.LEATHER_HELMET));
+            mob.getEquipment().setHelmetDropChance(0.0f); // Prevent helmet drop
+        }
     }
 
     // Apply wave-based attributes

--- a/src/main/java/city/emerald/bastion/wave/WaveManager.java
+++ b/src/main/java/city/emerald/bastion/wave/WaveManager.java
@@ -59,9 +59,11 @@ public class WaveManager {
     // Calculate mob count based on wave number (more appropriate than player count for initial calculation)
     this.remainingMobs = calculateMobCount(waveNumber);
 
+    long preparationDelaySeconds = plugin.getConfig().getLong("wave.preparation_delay_seconds", 10L);
+
     // Announce wave start
     Bukkit.broadcastMessage(
-      "§6Wave " + waveNumber + " starting in 10 seconds!"
+      "§6Wave " + waveNumber + " starting in " + preparationDelaySeconds + " seconds!"
     );
 
     // Start wave after delay
@@ -84,7 +86,7 @@ public class WaveManager {
           // Announce the wave start
           Bukkit.broadcastMessage("§cWave " + waveNumber + " has begun!");
         },
-        200L
+        preparationDelaySeconds * 20L
       ); // 10 seconds * 20 ticks
   }
 
@@ -103,6 +105,8 @@ public class WaveManager {
       });
     }
 
+    long completionDelaySeconds = plugin.getConfig().getLong("wave.completion_delay_seconds", 10L);
+
     // Start next wave after delay
     Bukkit
       .getScheduler()
@@ -111,7 +115,7 @@ public class WaveManager {
         () -> {
           startWave(currentWave + 1);
         },
-        200L
+        completionDelaySeconds * 20L
       ); // 10 seconds * 20 ticks
   }
 

--- a/src/main/java/city/emerald/bastion/wave/WaveManager.java
+++ b/src/main/java/city/emerald/bastion/wave/WaveManager.java
@@ -75,12 +75,16 @@ public class WaveManager {
           this.waveState = WaveState.ACTIVE;
           this.currentWave = waveNumber;
           this.gameStateManager.setCurrentWaveNumber(waveNumber);
-          // Remove duplicate assignment - remainingMobs already set above
           this.difficultyMultiplier = 1.0 + (waveNumber * 0.1);
 
           // Start lightning strikes on boss waves
           if (waveNumber > 0 && waveNumber % 10 == 0) {
             lightningManager.start();
+          }
+
+          // Spawn the wave using the new system
+          if (mobSpawnManager != null) {
+            mobSpawnManager.spawnWave(waveNumber, remainingMobs);
           }
 
           // Announce the wave start

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,10 @@ admins:
   - "spraguerilla"
 
 wave:
+  # Time in seconds to wait after a wave is completed before starting the next one.
+  completion_delay_seconds: 10
+  # Time in seconds for the countdown before a new wave becomes active.
+  preparation_delay_seconds: 10
   # UNUSED: Base number of mobs per wave (before player scaling)
   base_mob_count: 10
   # UNUSED: Additional mobs per player
@@ -117,3 +121,22 @@ bonus_loot:
   creeper: "tnt"
   enderman: "totem_of_undying"
   witch: "ghast_tear"
+
+# Defines the difficulty score for each mob type, used for calculating wave difficulty.
+# The score is a scalar based on health, damage, speed, and special abilities.
+# Zombie is the baseline at 1.0.
+mob_difficulty:
+  zombie: 1.0
+  skeleton: 1.2
+  stray: 1.4
+  spider: 1.3
+  cave_spider: 1.5
+  creeper: 1.8
+  phantom: 1.6
+  witch: 2.5
+  enderman: 2.2
+  vindicator: 2.0
+  pillager: 1.3
+  evoker: 3.5
+  vex: 1.7
+  ravager: 4.0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,16 @@ wave:
   completion_delay_seconds: 10
   # Time in seconds for the countdown before a new wave becomes active.
   preparation_delay_seconds: 10
+
+  # Parameters for the wave difficulty generation heuristic.
+  difficulty_scaling:
+    # The target average difficulty for the first wave.
+    starting_average_difficulty: 1.0
+    # The percentage increase in target difficulty for each subsequent wave.
+    average_difficulty_increase_percent: 5.0
+    # The number of consecutive failed attempts to improve the mob set before halting.
+    max_failed_swaps: 50
+
   # UNUSED: Base number of mobs per wave (before player scaling)
   base_mob_count: 10
   # UNUSED: Additional mobs per player


### PR DESCRIPTION
# Branch: feat/wave-spawn

## Summary

This branch overhauls the wave spawning mechanism, replacing the old, continuous, type-based spawning with a new heuristic-driven system that generates and spawns the entire mob set at the beginning of each wave. The new system is highly configurable and designed to create more diverse, balanced, and progressively challenging waves.

## Key Changes

### 1. New Wave Generation Heuristic
- **Wave Composition:** Instead of spawning mobs from a predefined list for each wave tier, the system now procedurally generates a unique set of mobs for every wave.
- **Difficulty-Based Algorithm:**
    - A target average difficulty is calculated for each wave, which increases with the wave number.
    - The system starts with a baseline set of Zombies and iteratively swaps them with other mob types.
    - A swap is only accepted if it brings the wave's average difficulty closer to the target without exceeding it, ensuring a gradual and controlled increase in challenge.
- **Configuration:** The entire heuristic is controlled via new settings in `config.yml`, including a `mob_difficulty` table and parameters for the scaling algorithm.

### 2. Configuration-Driven Wave Timers
- The hardcoded delays between waves have been removed.
- The `completion_delay_seconds` and `preparation_delay_seconds` can now be configured in `config.yml`, allowing for full control over the pacing of the game.

### 3. Daylight Mob Burning Fix
- Zombies and Skeletons are now automatically equipped with a non-droppable leather helmet upon spawning.
- This prevents them from burning in daylight, ensuring wave difficulty is consistent regardless of the in-game time of day.

### 4. Code Refactoring
- The old, timed-based spawning logic (`startSpawning`, `trySpawnMob`, etc.) in `MobSpawnManager` has been removed and replaced with the new `spawnWave` and `generateMobListForWave` methods.
- `WaveManager` has been updated to call the new `spawnWave` method, completing the integration.

## Testing confirmed in manual play test
1. Started the server and used `/bastion start` to begin the waves.
2. Observed the console logs at the start of each wave to see the "Generated mob set for wave..." message, which includes the calculated average difficulty.
3. Verified that the variety of mobs increases and changes with each wave.
4. Confirm that Zombies and Skeletons no longer burn during