### PR TITLE
Feature/fix respawn and village selection

### DIFF
--- a/src/main/java/city/emerald/bastion/Bastion.java
+++ b/src/main/java/city/emerald/bastion/Bastion.java
@@ -175,7 +175,14 @@ public final class Bastion extends JavaPlugin implements Listener {
           Player player = (Player) sender;
           if (villageManager.findAndSelectVillage(player.getWorld())) {
             sender.sendMessage("§aVillage found and selected!");
-            barrierManager.teleportToVillageCenter(player);
+            
+            // Teleport all online players to the village
+            for (Player onlinePlayer : getServer().getOnlinePlayers()) {
+              barrierManager.teleportToVillageCenter(onlinePlayer);
+            }
+            
+            // Announce to all players
+            getServer().broadcastMessage("§aAll players have been teleported to the selected village!");
           } else {
             sender.sendMessage("§cNo valid village found nearby!");
           }
@@ -198,6 +205,8 @@ public final class Bastion extends JavaPlugin implements Listener {
             sender.sendMessage("§cBarrier deactivated.");
           } else {
             barrierManager.activate();
+            // Register villagers now that players are in the village and chunks are loaded
+            //villageManager.registerVillagersInRange(((Player) sender).getWorld());
             sender.sendMessage("§aBarrier activated!");
           }
           break;
@@ -218,6 +227,8 @@ public final class Bastion extends JavaPlugin implements Listener {
             );
             return true;
           }
+          // Ensure villagers are registered before starting the game
+          villageManager.registerVillagersInRange(((Player) sender).getWorld());
           gameStateManager.startGame();
           statsManager.onGameStart();
           sender.sendMessage("§aStarting new game...");

--- a/src/main/java/city/emerald/bastion/VillageManager.java
+++ b/src/main/java/city/emerald/bastion/VillageManager.java
@@ -63,29 +63,14 @@ public class VillageManager {
       // We found a village structure, set spawn location
       Location spawnLoc = findSafeLocation(nearestVillage);
       this.villageCenter = spawnLoc;
-      world.setSpawnLocation(spawnLoc);
-
-      // We need to load the chunk to register villagers
+      world.setSpawnLocation(spawnLoc);      // We need to load the chunk to register villagers
       spawnLoc.getChunk().load();
-        plugin
-          .getServer()
-          .getScheduler()
-          .runTaskLater(
-            plugin,
-            () -> {
-              registerVillagersInRange(world);
-              plugin
-                .getLogger()
-                .info(
-                  "Village selected and spawn set. " +
-                  registeredVillagers.size() +
-                  " villagers registered."
-                );
-            },
-            20L
-          ); // Delay to allow chunk to fully load
+      
+      plugin
+        .getLogger()
+        .info("Village selected and spawn set.");
 
-        return true;
+      return true;
     } else {
       plugin
         .getLogger()
@@ -177,7 +162,7 @@ public class VillageManager {
    * Registers all villagers within the barrier range.
    * @param world The world to search in
    */
-  private void registerVillagersInRange(World world) {
+  public void registerVillagersInRange(World world) {
     registeredVillagers.clear();
     // Get barrier radius from config, fallback to 80 if barrier manager not set
     int radius = barrierManager != null

--- a/src/main/java/city/emerald/bastion/VillageManager.java
+++ b/src/main/java/city/emerald/bastion/VillageManager.java
@@ -1,6 +1,7 @@
 package city.emerald.bastion;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,15 +60,13 @@ public class VillageManager {
         .getLogger()
         .info("Found a village structure at: " + nearestVillage.toVector());
 
-      // We found a village structure, now validate it has enough villagers
-      if (isValidVillageLocation(nearestVillage) &&
-        hasEnoughVillagers(nearestVillage, world)) {
-        Location spawnLoc = findSafeLocation(nearestVillage);
-        this.villageCenter = spawnLoc;
-        world.setSpawnLocation(spawnLoc);
+      // We found a village structure, set spawn location
+      Location spawnLoc = findSafeLocation(nearestVillage);
+      this.villageCenter = spawnLoc;
+      world.setSpawnLocation(spawnLoc);
 
-        // We need to load the chunk to register villagers
-        spawnLoc.getChunk().load();
+      // We need to load the chunk to register villagers
+      spawnLoc.getChunk().load();
         plugin
           .getServer()
           .getScheduler()
@@ -87,14 +86,6 @@ public class VillageManager {
           ); // Delay to allow chunk to fully load
 
         return true;
-      } else {
-        plugin
-          .getLogger()
-          .warning(
-            "Found a village structure, but it's not suitable (insufficient solid ground or fewer than 4 villagers)."
-          );
-        return false;
-      }
     } else {
       plugin
         .getLogger()
@@ -140,16 +131,35 @@ public class VillageManager {
   private boolean hasEnoughVillagers(Location villageLocation, World world) {
     int radius = getBarrierRadius();
     int villagerCount = 0;
+    int requiredVillagers = 4;
 
-    // Load the chunk to ensure villagers are loaded
-    villageLocation.getChunk().load();
-
-    // Count villagers within the barrier radius
-    for (Entity entity : world.getEntities()) {
-      if (entity.getType() == EntityType.VILLAGER) {
-        if (isInRange(entity.getLocation(), villageLocation, radius)) {
-          villagerCount++;
-        }
+    plugin.getLogger().info("DEBUG: Searching for villagers in radius: " + radius);
+    plugin.getLogger().info("DEBUG: Village location: " + villageLocation);
+    
+    // Load just the center chunk and a few nearby chunks
+    int centerChunkX = villageLocation.getBlockX() >> 4;
+    int centerChunkZ = villageLocation.getBlockZ() >> 4;
+    
+    // Load a 3x3 area of chunks around the village
+    for (int x = -1; x <= 1; x++) {
+      for (int z = -1; z <= 1; z++) {
+        world.getChunkAt(centerChunkX + x, centerChunkZ + z).load();
+      }
+    }
+    
+    plugin.getLogger().info("DEBUG: Loaded 3x3 chunk area");
+    
+    // Use getEntitiesByClass to find villagers more reliably
+    Collection<Villager> villagers = world.getEntitiesByClass(Villager.class);
+    
+    plugin.getLogger().info("DEBUG: Found " + villagers.size() + " total villagers in world");
+    
+    // Count villagers within radius
+    for (Villager villager : villagers) {
+      double distance = villager.getLocation().distance(villageLocation);
+      if (distance <= radius) {
+        villagerCount++;
+        plugin.getLogger().info("DEBUG: Villager at " + villager.getLocation() + " is " + distance + " blocks away");
       }
     }
 


### PR DESCRIPTION
# Summary of Changes in feature/fix-respawn-and-village-selection Branch

## Issue Fixed
Players were respawning at the wrong village location after death. When using /bastion findvillage to select a new village, players would still respawn at the previously selected village instead of the newly selected one.

## Root Cause Analysis
The issue was caused by two main problems:
1. Bed spawn override - Players had bed spawn points set that overrode the world spawn location
2. Chunk loading issues - Village validation was causing server timeouts due to synchronous chunk loading

## Changes Made

### 1. VillageManager.java
- Removed problematic terrain validation that was causing chunk loading timeouts
- Removed villager count validation that was failing due to chunks not being loaded
- Simplified village selection to only check for village structure existence and immediately set spawn location
- Moved villager registration out of village selection to prevent chunk loading issues
- Made registerVillagersInRange() public so it can be called from command handlers

### 2. Bastion.java
- Modified /bastion findvillage command to teleport all online players to the selected village
- Moved villager registration to /bastion start command when players are present and chunks loaded
- Added server-wide announcement when players are teleported to village

## Technical Details
The original village validation was causing server timeouts by synchronously loading many chunks. The fix removes this validation and moves villager registration to when it's actually needed during