### PR TITLE
Feat/non stacking loot

### DIFF
--- a/src/main/java/city/emerald/bastion/economy/LootManager.java
+++ b/src/main/java/city/emerald/bastion/economy/LootManager.java
@@ -156,11 +156,16 @@ public class LootManager {
         // Determine a random quantity from 1 to maxAmount
         int baseAmount = random.nextInt(entry.maxAmount) + 1;
         
-        // Apply the multiplier and round to the nearest whole number
-        int finalAmount = (int) Math.round(baseAmount * multiplier);
-
-        if (finalAmount > 0) {
-          loot.add(new ItemStack(entry.material, finalAmount));
+        // Check if this is a non-stacking item (max stack size of 1)
+        if (entry.material.getMaxStackSize() == 1) {
+          // Non-stacking item - always give exactly 1, ignore multipliers
+          loot.add(new ItemStack(entry.material, 1));
+        } else {
+          // Stackable item - apply the multiplier and round to the nearest whole number
+          int finalAmount = (int) Math.round(baseAmount * multiplier);
+          if (finalAmount > 0) {
+            loot.add(new ItemStack(entry.material, finalAmount));
+          }
         }
       }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -93,15 +93,15 @@ loot_table_settings:
 
 common_loot:
   # Stage 1: Basic Survival & Villager Care
-  zombie: "wheat,potatoes,carrots,beetroots,raw_beef,raw_pork,oak_log,sticks,string,feathers,flint,wool,rotten_flesh,coal"
-  slime: "wheat,potatoes,carrots,raw_fish,oak_log,sticks,string,feathers,wool,coal"
-  spider: "wheat,beetroots,melons,raw_chicken,oak_log,sticks,string,feathers,flint,rotten_flesh,coal"
-  skeleton: "raw_beef,raw_pork,raw_fish,oak_log,sticks,string,feathers,flint,wool,coal"
+  zombie: "wheat,potatoes,carrots,beetroots,raw_beef,wool,raw_pork,oak_log,sticks,string,feathers,flint,wool,rotten_flesh,coal"
+  slime: "wheat,potatoes,carrots,cod,oak_log,sticks,string,feathers,wool,coal"
+  spider: "wheat,beetroots,melon,raw_chicken,oak_log,sticks,string,feathers,flint,rotten_flesh,coal"
+  skeleton: "raw_beef,raw_pork,cod,oak_log,sticks,string,feathers,flint,wool,coal"
   # Stage 2: Infrastructure & Early Trading
-  husk: "oak_log,sand,sugar_cane,books,coal,iron_ingot,pumpkin,leather,string,feathers"
+  husk: "oak_log,sand,sugar_cane,book,coal,iron_ingot,pumpkin,leather,string,feathers"
   creeper: "oak_log,sand,sugar_cane,paper,coal,iron_ingot,pumpkin,leather,gunpowder"
-  pillager: "sand,sugar_cane,paper,books,coal,iron_ingot,leather,string,feathers"
-  magma_cube: "oak_log,sand,sugar_cane,books,iron_ingot,pumpkin,leather,magma_cream"
+  pillager: "sand,pumpkin,sugar_cane,paper,book,coal,iron_ingot,leather,string,feathers"
+  magma_cube: "oak_log,sand,sugar_cane,book,iron_ingot,pumpkin,leather,magma_cream"
   # Stage 3: Iron Age & Basic Enchanting
   stray: "iron_ingot,gold_ingot,gold_nugget,diamond,leather,paper,emerald,experience_bottle,sand,spider_eye"
   cave_spider: "iron_ingot,gold_ingot,gold_nugget,diamond,paper,emerald,experience_bottle,spider_eye"
@@ -111,15 +111,15 @@ common_loot:
   zoglin: "lapis_lazuli,diamond,obsidian,blaze_rod,blaze_powder,nether_wart,slimeball,emerald,gold_ingot"
   vindicator: "lapis_lazuli,diamond,obsidian,blaze_powder,nether_wart,sugar,spider_eye,brown_mushroom,emerald,gold_ingot"
   # Stage 5: Master Brewing & Advanced Resources
-  blaze: "ghast_tear,magma_cream,pufferfish,phantom_membrane,melon_slice,gold_nugget,nether_quartz_ore,clay,cactus,moss_block,sculk"
-  enderman: "ghast_tear,magma_cream,phantom_membrane,melon_slice,gold_nugget,nether_quartz_ore,clay,moss_block,sculk,ender_pearl,obsidian"
+  blaze: "ghast_tear,magma_cream,pufferfish,phantom_membrane,melon_slice,gold_nugget,nether_quartz,clay,cactus,moss_block,sculk"
+  enderman: "ghast_tear,magma_cream,phantom_membrane,melon_slice,gold_nugget,nether_quartz,clay,moss_block,sculk,ender_pearl,obsidian"
   witch: "ghast_tear,magma_cream,pufferfish,phantom_membrane,gold_nugget,clay,cactus,moss_block,sculk,lapis_lazuli,redstone,glowstone_dust"
-  wither_skeleton: "ghast_tear,magma_cream,pufferfish,phantom_membrane,nether_quartz_ore,clay,cactus,sculk,wither_skeleton_skull"
+  wither_skeleton: "ghast_tear,magma_cream,pufferfish,phantom_membrane,clay,cactus,sculk,wither_skeleton_skull"
   # Stage 6: Endgame Mastery
-  ravager: "ancient_debris,dragon_breath,ghast_tear,magma_cream,phantom_membrane,gold_nugget,nether_quartz_ore,clay,moss_block,sculk,diamond,emerald"
-  evoker: "ancient_debris,dragon_breath,ghast_tear,pufferfish,phantom_membrane,nether_quartz_ore,sculk,totem_of_undying,emerald"
-  vex: "ancient_debris,dragon_breath,phantom_membrane,nether_quartz_ore,clay,sculk,totem_of_undying"
-  ghast: "ancient_debris,dragon_breath,ghast_tear,magma_cream,pufferfish,phantom_membrane,gold_nugget,nether_quartz_ore,sculk,fire_charge"
+  ravager: "ancient_debris,dragon_breath,ghast_tear,magma_cream,phantom_membrane,gold_nugget,clay,moss_block,sculk,diamond,emerald"
+  evoker: "ancient_debris,dragon_breath,ghast_tear,pufferfish,phantom_membrane,sculk,totem_of_undying,emerald"
+  vex: "ancient_debris,dragon_breath,phantom_membrane,clay,sculk,totem_of_undying"
+  ghast: "ancient_debris,dragon_breath,ghast_tear,magma_cream,pufferfish,phantom_membrane,gold_nugget,sculk,fire_charge"
 
 bonus_loot:
   # Stage 1: Basic Survival Bonus
@@ -129,29 +129,29 @@ bonus_loot:
   skeleton: "bone_meal,experience_bottle,book,emerald"
   
   # Stage 2: Infrastructure Bonus
-  husk: "iron_ingot,leather_helmet,golden_apple,emerald"
+  husk: "iron_nugget,gold_nugget,golden_apple,emerald"
   creeper: "tnt,gunpowder,iron_ingot,golden_apple,emerald"
-  pillager: "crossbow,iron_ingot,white_banner,emerald"
+  pillager: "iron_ingot,gold_nugget,arrow,emerald"
   magma_cube: "magma_block,iron_ingot,emerald"
   
   # Stage 3: Iron Age Bonus
   stray: "ice,packed_ice,arrow,emerald,book"
   cave_spider: "spider_eye,experience_bottle,emerald,book"
-  zombified_piglin: "gold_ingot,golden_sword,emerald,book"
+  zombified_piglin: "gold_ingot,emerald,book,glass_bottle"
   
   # Stage 4: Advanced Magic Bonus
   phantom: "elytra,phantom_membrane,emerald,book"
-  zoglin: "leather,cooked_porkchop,emerald,book"
-  vindicator:  "emerald_block,emerald,book"
+  zoglin: "obsidian,leather,cooked_porkchop,emerald,book,glass_bottle"
+  vindicator:  "obsidian,emerald_block,emerald,book"
   
   # Stage 5: Master Brewing Bonus
-  blaze: "brewing_stand,blaze_rod,book"
-  enderman: "ender_chest,shulker_box,ender_pearl,book"
-  witch: "cauldron,brewing_stand,book"
+  blaze: "blaze_rod,book"
+  enderman: "shulker_shell,ender_pearl,book"
+  witch: "book,glass_bottle"
   wither_skeleton: "wither_skeleton_skull,totem_of_undying,book"
   
   # Stage 6: Endgame Bonus
-  ravager: "saddle,lead,emerald_block,book"
+  ravager: "lead,emerald_block,book"
   evoker: "totem_of_undying,emerald_block,emerald,book"
   vex: "totem_of_undying,phantom_membrane,emerald,book"
   ghast: "ghast_tear,fire_charge,dragon_breath,book"


### PR DESCRIPTION
# Non-Stacking Loot Management Enhancement

## Summary
This PR improves loot drop handling for non-stacking items by cleaning up loot tables 
and implementing smart quantity limiting in the drop system.

## Changes Made

### Loot Table Cleanup (commit 703d1fb)
- Removed invalid item names from loot tables that would cause errors
- Removed most non-stacking items from loot tables to prevent inventory issues
- Kept totems of undying as the primary non-stacking reward item
- Fixed item naming inconsistencies for proper Minecraft compatibility

### Smart Drop Quantity Limiting (commit abe0c06)  
- Enhanced LootManager.java with intelligent non-stacking item detection
- Implemented automatic detection using Material.getMaxStackSize() == 1
- Non-stacking items now always drop exactly 1 item regardless of multipliers
- Preserves existing multiplier system for stackable items
- Future-proof solution that works with any Minecraft non-stacking items

## Technical Details

### Files Modified
- `src/main/resources/config.yml`: Cleaned up loot table entries
- `src/main/java/city/emerald/bastion/economy/LootManager.java`: Added smart quantity limiting

### Logic Enhancement
Before: All items subject to wave multipliers and elite/boss bonuses
After: Non-stacking items bypass multipliers, stackable items use existing system

### Benefits
- Prevents multiple non-stacking items in single drops
- Maintains game balance for rare items like Totems of Undying
- Automatic detection requires no maintenance for new items
- Backward compatible with existing loot mechanics

## Impact
Players will no longer receive multiple copies of non-stacking items like totems 
from high-wave multipliers or elite/boss kills, maintaining proper game balance 
while preserving the reward scaling for stackable resources.